### PR TITLE
GitOpsによるリリース

### DIFF
--- a/kubernetes/values/prd.yaml
+++ b/kubernetes/values/prd.yaml
@@ -6,6 +6,7 @@ image:
       gin: latest
     customer:
       fastapi: latest
+      '""': 60963c5
     orchestrator:
       fastapi: latest
     order:


### PR DESCRIPTION
[microservices-backendリポジトリのリリース](https://github.com/hiroki-it/microservices-backend/commit/60963c5) のため、マニフェストファイルのイメージのタグを更新します。