### PR TITLE
GitOpsによるリリース

### DIFF
--- a/kubernetes/values/prd.yaml
+++ b/kubernetes/values/prd.yaml
@@ -5,7 +5,7 @@ image:
     account:
       gin: latest
     customer:
-      fastapi: latest
+      fastapi: "0431585"
     orchestrator:
       fastapi: latest
     order:


### PR DESCRIPTION
[microservices-backendリポジトリのリリース](https://github.com/hiroki-it/microservices-backend/commit/0431585) のため、マニフェストファイルのイメージのタグを更新します。