### PR TITLE
GitOpsによるリリース

### DIFF
--- a/values/prd.yaml
+++ b/values/prd.yaml
@@ -11,7 +11,7 @@ image:
     account:
       gin: latest
     customer:
-      fastapi: "0431585"
+      fastapi: "06d8423"
     orchestrator:
       fastapi: latest
     order:


### PR DESCRIPTION
[microservices-backendリポジトリのリリース](https://github.com/hiroki-it/microservices-backend/commit/06d8423) のため、マニフェストファイルのイメージのタグを更新します。