### PR TITLE
GitOpsによるリリース

### DIFF
--- a/release/prd/argocd.yaml
+++ b/release/prd/argocd.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://github.com/hiroki-it/microservices-manifests.git
     targetRevision: main
-    path: release/prd
+    path: ./release/prd
     directory:
       include: kubernetes.yaml
   destination:

--- a/release/prd/kubernetes.yaml
+++ b/release/prd/kubernetes.yaml
@@ -251,7 +251,7 @@ spec:
           ports:
             - containerPort: 9000
         - name: nginx
-          image: order-nginx:latest
+          image: order-nginx:b5d0574
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/values/prd.yaml
+++ b/values/prd.yaml
@@ -16,4 +16,4 @@ kubernetes:
       fastapi: latest
     order:
       lumen: latest
-      nginx: latest
+      nginx: b5d0574


### PR DESCRIPTION
[microservices-backendリポジトリのリリース](https://github.com/hiroki-it/microservices-backend/commit/b5d0574) のため、マニフェストファイルのイメージのタグを更新します。