### PR TITLE
GitOpsによるリリース

### DIFF
--- a/release/prd/argocd.yaml
+++ b/release/prd/argocd.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://github.com/hiroki-it/microservices-manifests.git
     targetRevision: main
-    path: release/prd
+    path: ./release/prd
     directory:
       include: kubernetes.yaml
   destination:

--- a/release/prd/kubernetes.yaml
+++ b/release/prd/kubernetes.yaml
@@ -246,7 +246,7 @@ spec:
       containers:
         # Lumenコンテナ
         - name: lumen
-          image: order-lumen:latest
+          image: order-lumen:b5d0574
           imagePullPolicy: Always
           ports:
             - containerPort: 9000

--- a/values/prd.yaml
+++ b/values/prd.yaml
@@ -15,5 +15,5 @@ kubernetes:
     orchestrator:
       fastapi: latest
     order:
-      lumen: latest
+      lumen: b5d0574
       nginx: latest


### PR DESCRIPTION
[microservices-backendリポジトリのリリース](https://github.com/hiroki-it/microservices-backend/commit/b5d0574) のため、マニフェストファイルのイメージのタグを更新します。