### PR TITLE
GitOpsによるリリース

### DIFF
--- a/release/prd/argocd.yaml
+++ b/release/prd/argocd.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://github.com/hiroki-it/microservices-manifests.git
     targetRevision: main
-    path: release/prd
+    path: ./release/prd
     directory:
       include: kubernetes.yaml
   destination:

--- a/release/prd/kubernetes.yaml
+++ b/release/prd/kubernetes.yaml
@@ -207,7 +207,7 @@ spec:
       containers:
         # FastAPIコンテナ
         - name: fastapi
-          image: orchestrator-fastapi:latest
+          image: orchestrator-fastapi:00690e9
           imagePullPolicy: Always
           ports:
             - containerPort: 8000

--- a/values/prd.yaml
+++ b/values/prd.yaml
@@ -13,7 +13,7 @@ kubernetes:
     customer:
       fastapi: "a0e4ba5"
     orchestrator:
-      fastapi: latest
+      fastapi: "00690e9"
     order:
       lumen: latest
       nginx: latest


### PR DESCRIPTION
[microservices-backendリポジトリのリリース](https://github.com/hiroki-it/microservices-backend/commit/00690e9) のため、マニフェストファイルのイメージのタグを更新します。