### PR TITLE
GitOpsによるリリース

### DIFF
--- a/release/prd/argocd.yaml
+++ b/release/prd/argocd.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://github.com/hiroki-it/microservices-manifests.git
     targetRevision: main
-    path: release/prd
+    path: ./release/prd
     directory:
       include: kubernetes.yaml
   destination:

--- a/release/prd/kubernetes.yaml
+++ b/release/prd/kubernetes.yaml
@@ -132,7 +132,7 @@ spec:
       containers:
         # Ginコンテナ
         - name: gin
-          image: account-gin:latest
+          image: account-gin:d74ac1c
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/values/prd.yaml
+++ b/values/prd.yaml
@@ -9,7 +9,7 @@ general:
 kubernetes:
   image:
     account:
-      gin: latest
+      gin: d74ac1c
     customer:
       fastapi: "a0e4ba5"
     orchestrator:


### PR DESCRIPTION
[microservices-backendリポジトリのリリース](https://github.com/hiroki-it/microservices-backend/commit/d74ac1c) のため、マニフェストファイルのイメージのタグを更新します。