### PR TITLE
GitOpsによるリリース

### DIFF
--- a/release/prd/kubernetes/kubernetes.yaml
+++ b/release/prd/kubernetes/kubernetes.yaml
@@ -163,7 +163,7 @@ spec:
       containers:
         # FastAPIコンテナ
         - name: fastapi
-          image: .dkr.ecr..amazonaws.com/customer-fastapi-repository:cad5c87
+          image: .dkr.ecr..amazonaws.com/customer-fastapi-repository:248db64
           imagePullPolicy: Always
           ports:
             - containerPort: 8000

--- a/values/prd.yaml
+++ b/values/prd.yaml
@@ -21,7 +21,7 @@ kubernetes:
     account:
       gin: d74ac1c
     customer:
-      fastapi: cad5c87
+      fastapi: 248db64
     orchestrator:
       fastapi: 00690e9
     order:


### PR DESCRIPTION
[microservices-backendリポジトリのリリース](https://github.com/hiroki-it/microservices-backend/commit/248db64) のため、マニフェストファイルのイメージのタグを更新します。